### PR TITLE
Update importer.gd

### DIFF
--- a/addons/ninetailsrabbit.character_generator_importer_tool/plugin.cfg
+++ b/addons/ninetailsrabbit.character_generator_importer_tool/plugin.cfg
@@ -3,5 +3,5 @@
 name="Character generator importer tool"
 description="This is an unofficial tool that can be used as a plugin in Godot to speed up the process of creating animations for the character generator"
 author="Ninetailsrabbit"
-version="1.1.0"
+version="1.1.1"
 script="ninetailsrabbit.character_generator_importer_tool.gd"

--- a/addons/ninetailsrabbit.character_generator_importer_tool/src/importer.gd
+++ b/addons/ninetailsrabbit.character_generator_importer_tool/src/importer.gd
@@ -937,7 +937,7 @@ func _get_frame_data_based_on_size(animation: String, sprite_size: SpriteSizes) 
 				SpriteSizes.Size32x32:
 					return {"position": Vector2(0, 384), "size": size_32_default, "loopable": true} 
 				SpriteSizes.Size48x48:
-					return {"position": Vector2(0, 476), "size": size_48_default, "loopable": true}
+					return {"position": Vector2(0, 576), "size": size_48_default, "loopable": true}
 		"walk_with_object":
 			match sprite_size:
 				SpriteSizes.Size16x16:
@@ -985,7 +985,7 @@ func _get_frame_data_based_on_size(animation: String, sprite_size: SpriteSizes) 
 				SpriteSizes.Size32x32:
 					return {"position": Vector2(0, 896), "size": size_32_default, "loopable": false} 
 				SpriteSizes.Size48x48:
-					return {"position": Vector2(0, 1340), "size": size_48_default, "loopable": false}
+					return {"position": Vector2(0, 1344), "size": size_48_default, "loopable": false}
 		"punch_variant":
 			match sprite_size:
 				SpriteSizes.Size16x16:
@@ -1026,7 +1026,7 @@ func _get_frame_data_based_on_size(animation: String, sprite_size: SpriteSizes) 
 				SpriteSizes.Size32x32:
 					return {"position": Vector2(0, 1216), "size": size_32_default, "loopable": true} 
 				SpriteSizes.Size48x48:
-					return {"position": Vector2(0, 1818), "size": size_48_default, "loopable": true}
+					return {"position": Vector2(0, 1824), "size": size_48_default, "loopable": true}
 	return {}
 
 


### PR DESCRIPTION
Fixed coordinates for three animations (hurt, punch, phone) on 48 pixel spritesheets.

## Description

The following issues occured when importing animations with a 48 pixel spritesize:
1. The animations for "_hurt_" and "_punch_" had the character's feet were chopped off and artifacts (feet from a different animation) were displayed above the character.
2. The animations for "_phone_" did not show any phone-sprites at all and instead showed sprites from a different animation.


All isses were fixed by changing the coordinates.

![misalignment](https://github.com/user-attachments/assets/a4f74a44-1731-4d20-8f10-c4914abcfbc0)
